### PR TITLE
ContentPack API

### DIFF
--- a/src/main/java/com/whisent/kubeloader/Kubeloader.java
+++ b/src/main/java/com/whisent/kubeloader/Kubeloader.java
@@ -15,6 +15,7 @@ import net.minecraftforge.event.AddPackFindersEvent;
 import net.minecraftforge.event.server.ServerStartingEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.ModList;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
@@ -59,7 +60,8 @@ public class Kubeloader {
     }
 
     private static void registerContentPackProviders() {
-        var providers = Platform.getMods()
+        var providers = ModList.get()
+            .getMods()
             .stream()
             .map(ModContentPackProvider::new)
             .toArray(ContentPackProvider[]::new);

--- a/src/main/java/com/whisent/kubeloader/Kubeloader.java
+++ b/src/main/java/com/whisent/kubeloader/Kubeloader.java
@@ -1,22 +1,20 @@
 package com.whisent.kubeloader;
 
 import com.mojang.logging.LogUtils;
-import com.sun.jna.Platform;
+import com.whisent.kubeloader.definition.ContentPackProvider;
 import com.whisent.kubeloader.files.*;
+import com.whisent.kubeloader.impl.ContentPackProviders;
+import com.whisent.kubeloader.impl.mod.ModContentPackProvider;
+import dev.architectury.platform.Platform;
 import dev.latvian.mods.kubejs.KubeJS;
 import dev.latvian.mods.kubejs.KubeJSPaths;
-import dev.latvian.mods.kubejs.script.ScriptManager;
-import dev.latvian.mods.kubejs.script.ScriptType;
-import dev.latvian.mods.kubejs.util.ConsoleJS;
 import net.minecraft.client.Minecraft;
 import net.minecraft.server.packs.PackType;
-import net.minecraft.server.packs.repository.RepositorySource;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.event.AddPackFindersEvent;
 import net.minecraftforge.event.server.ServerStartingEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.fml.ModList;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
@@ -33,8 +31,9 @@ import java.util.List;
 public class Kubeloader {
     public static final String MODID = "kubeloader";
     public static final Logger LOGGER = LogUtils.getLogger();
+    public static final String FOLDER_NAME = "contentpacks";
     public static Path ResourcePath = KubeJSPaths.DIRECTORY.resolve("pack_resources");
-    public static Path PackPath = KubeJSPaths.DIRECTORY.resolve("contentpacks");
+    public static Path PackPath = KubeJSPaths.DIRECTORY.resolve(FOLDER_NAME);
 
     public Kubeloader() throws IOException {
         IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
@@ -56,6 +55,15 @@ public class Kubeloader {
         modEventBus.addListener(this::ModLoding);
         FMLJavaModLoadingContext.get().getModEventBus().addListener(this::injectPacks);
 
+        registerContentPackProviders();
+    }
+
+    private static void registerContentPackProviders() {
+        var providers = Platform.getMods()
+            .stream()
+            .map(ModContentPackProvider::new)
+            .toArray(ContentPackProvider[]::new);
+        ContentPackProviders.register(providers);
     }
 
     private void ModLoding(FMLClientSetupEvent event) {
@@ -68,14 +76,10 @@ public class Kubeloader {
         InjectFiles(PackPath,"data");
         switch (event.getPackType()) {
             case CLIENT_RESOURCES -> {
-                event.addRepositorySource((RepositorySource)
-                        new ResourcePackProvider(ResourcePath
-                                , PackType.CLIENT_RESOURCES));
+                event.addRepositorySource(new ResourcePackProvider(ResourcePath, PackType.CLIENT_RESOURCES));
             }
             case SERVER_DATA -> {
-                event.addRepositorySource((RepositorySource)
-                        new ResourcePackProvider(ResourcePath
-                                ,PackType.SERVER_DATA));
+                event.addRepositorySource(new ResourcePackProvider(ResourcePath,PackType.SERVER_DATA));
             }
         }
     }

--- a/src/main/java/com/whisent/kubeloader/definition/ContentPack.java
+++ b/src/main/java/com/whisent/kubeloader/definition/ContentPack.java
@@ -1,0 +1,25 @@
+package com.whisent.kubeloader.definition;
+
+import dev.latvian.mods.kubejs.script.ScriptPack;
+import dev.latvian.mods.kubejs.script.ScriptType;
+import net.minecraft.resources.ResourceLocation;
+
+/**
+ * 一个 ContentPack 是 KubeJS 脚本（与资源）的集合，提供命名空间（{@link dev.latvian.mods.kubejs.script.ScriptPackInfo#namespace}
+ * ）独立的脚本执行环境以及命名空间（{@link ResourceLocation#getNamespace()}）独立的资源集合
+ *
+ * @author ZZZank
+ */
+public interface ContentPack {
+
+    String getNamespace();
+
+    /**
+     * 留作未来使用，或者可能也没用
+     */
+    default String getNamespace(ScriptType type) {
+        return getNamespace();
+    }
+
+    ScriptPack getPack(ScriptType type);
+}

--- a/src/main/java/com/whisent/kubeloader/definition/ContentPackProvider.java
+++ b/src/main/java/com/whisent/kubeloader/definition/ContentPackProvider.java
@@ -1,0 +1,15 @@
+package com.whisent.kubeloader.definition;
+
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * @author ZZZank
+ */
+public interface ContentPackProvider {
+
+    /**
+     * @return 该 ContentPackProvider 所提供的 ContentPack，或者，如果其没有，则返回 {@code null}
+     */
+    @Nullable
+    ContentPack providePack();
+}

--- a/src/main/java/com/whisent/kubeloader/impl/ContentPackProviders.java
+++ b/src/main/java/com/whisent/kubeloader/impl/ContentPackProviders.java
@@ -1,0 +1,38 @@
+package com.whisent.kubeloader.impl;
+
+import com.whisent.kubeloader.definition.ContentPack;
+import com.whisent.kubeloader.definition.ContentPackProvider;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * @author ZZZank
+ */
+public final class ContentPackProviders {
+    private static final List<ContentPackProvider> PROVIDERS = new ArrayList<>();
+    private static List<ContentPack> cachedPacks = null;
+
+    public static void register(ContentPackProvider... providers) {
+        for (var provider : providers) {
+            PROVIDERS.add(Objects.requireNonNull(provider));
+        }
+    }
+
+    public static List<ContentPackProvider> getProviders() {
+        return Collections.unmodifiableList(PROVIDERS);
+    }
+
+    public static List<ContentPack> getPacks() {
+        if (cachedPacks == null) {
+            cachedPacks = PROVIDERS
+                .stream()
+                .map(ContentPackProvider::providePack)
+                .filter(Objects::nonNull)
+                .toList();
+        }
+        return cachedPacks;
+    }
+}

--- a/src/main/java/com/whisent/kubeloader/impl/mod/ModContentPack.java
+++ b/src/main/java/com/whisent/kubeloader/impl/mod/ModContentPack.java
@@ -1,9 +1,9 @@
 package com.whisent.kubeloader.impl.mod;
 
 import com.whisent.kubeloader.definition.ContentPack;
-import dev.architectury.platform.Mod;
 import dev.latvian.mods.kubejs.script.ScriptPack;
 import dev.latvian.mods.kubejs.script.ScriptType;
+import net.minecraftforge.forgespi.language.IModInfo;
 
 import java.util.EnumMap;
 import java.util.Map;
@@ -12,10 +12,10 @@ import java.util.Map;
  * @author ZZZank
  */
 public class ModContentPack implements ContentPack {
-    private final Mod mod;
+    private final IModInfo mod;
     final Map<ScriptType, ScriptPack> packs = new EnumMap<>(ScriptType.class);
 
-    public ModContentPack(Mod mod) {
+    public ModContentPack(IModInfo mod) {
         this.mod = mod;
     }
 

--- a/src/main/java/com/whisent/kubeloader/impl/mod/ModContentPack.java
+++ b/src/main/java/com/whisent/kubeloader/impl/mod/ModContentPack.java
@@ -1,0 +1,31 @@
+package com.whisent.kubeloader.impl.mod;
+
+import com.whisent.kubeloader.definition.ContentPack;
+import dev.architectury.platform.Mod;
+import dev.latvian.mods.kubejs.script.ScriptPack;
+import dev.latvian.mods.kubejs.script.ScriptType;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+/**
+ * @author ZZZank
+ */
+public class ModContentPack implements ContentPack {
+    private final Mod mod;
+    final Map<ScriptType, ScriptPack> packs = new EnumMap<>(ScriptType.class);
+
+    public ModContentPack(Mod mod) {
+        this.mod = mod;
+    }
+
+    @Override
+    public String getNamespace() {
+        return mod.getModId();
+    }
+
+    @Override
+    public ScriptPack getPack(ScriptType type) {
+        return packs.get(type);
+    }
+}

--- a/src/main/java/com/whisent/kubeloader/impl/mod/ModContentPackProvider.java
+++ b/src/main/java/com/whisent/kubeloader/impl/mod/ModContentPackProvider.java
@@ -1,0 +1,99 @@
+package com.whisent.kubeloader.impl.mod;
+
+import com.whisent.kubeloader.Kubeloader;
+import com.whisent.kubeloader.definition.ContentPack;
+import com.whisent.kubeloader.definition.ContentPackProvider;
+import dev.architectury.platform.Mod;
+import dev.latvian.mods.kubejs.script.*;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+/**
+ * @author ZZZank
+ */
+public class ModContentPackProvider implements ContentPackProvider {
+    private static final Map<ScriptType, String> PREFIXES = new EnumMap<>(ScriptType.class);
+
+    static {
+        for (var scriptType : ScriptType.values()) {
+            PREFIXES.put(scriptType, Kubeloader.FOLDER_NAME + '/' + scriptType.name + '/');
+        }
+    }
+
+    private final Mod mod;
+
+    public ModContentPackProvider(Mod mod) {
+        this.mod = mod;
+    }
+
+    @Override
+    public @Nullable ContentPack providePack() {
+        return mod.getFilePaths()
+            .stream()
+            .map(this::scanSingle)
+            .filter(Objects::nonNull)
+            .findFirst()
+            .orElse(null);
+    }
+
+    private ContentPack scanSingle(Path path) {
+        try (var file = new JarFile(path.toFile())) {
+            if (file.getEntry(Kubeloader.FOLDER_NAME) == null) {
+                return null;
+            }
+
+            var contentPack = new ModContentPack(mod);
+            var entriesByType = collectEntries(file);
+
+            for (var entry : entriesByType.entrySet()) {
+                var type = entry.getKey();
+                var pack = new ScriptPack(
+                    type.manager.get(),
+                    new ScriptPackInfo(mod.getModId(), "")
+                );
+
+                for (var jarEntry : entry.getValue()) {
+                    var fileInfo = new ScriptFileInfo(pack.info, jarEntry.getName());
+                    var scriptSource = (ScriptSource) info -> {
+                        var reader = new BufferedReader(new InputStreamReader(file.getInputStream(jarEntry)));
+                        return reader.lines().toList();
+                    };
+                    pack.scripts.add(new ScriptFile(pack, fileInfo, scriptSource));
+                }
+
+                contentPack.packs.put(type, pack);
+            }
+            return contentPack;
+        } catch (IOException e) {
+            // log
+            return null;
+        }
+    }
+
+    private static @NotNull EnumMap<ScriptType, List<JarEntry>> collectEntries(JarFile file) {
+        var entries = file.stream()
+            .filter(e -> !e.isDirectory())
+            .filter(e -> e.getName().endsWith(".js"))
+            .filter(e -> e.getName().startsWith(Kubeloader.FOLDER_NAME + "/"))
+            .toList();
+
+        var entriesByType = new EnumMap<ScriptType, List<JarEntry>>(ScriptType.class);
+        for (var entry : entries) {
+            for (var matcher : PREFIXES.entrySet()) {
+                if (entry.getName().startsWith(matcher.getValue())) {
+                    entriesByType.computeIfAbsent(matcher.getKey(), k -> new ArrayList<>())
+                        .add(entry);
+                }
+            }
+        }
+        return entriesByType;
+    }
+}

--- a/src/main/java/com/whisent/kubeloader/impl/mod/ModContentPackProvider.java
+++ b/src/main/java/com/whisent/kubeloader/impl/mod/ModContentPackProvider.java
@@ -4,8 +4,8 @@ import com.whisent.kubeloader.Kubeloader;
 import com.whisent.kubeloader.definition.ContentPack;
 import com.whisent.kubeloader.definition.ContentPackProvider;
 import com.whisent.kubeloader.mixin.AccessScriptManager;
-import dev.architectury.platform.Mod;
 import dev.latvian.mods.kubejs.script.*;
+import net.minecraftforge.forgespi.language.IModInfo;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -29,20 +29,18 @@ public class ModContentPackProvider implements ContentPackProvider {
         }
     }
 
-    private final Mod mod;
+    private final IModInfo mod;
 
-    public ModContentPackProvider(Mod mod) {
+    public ModContentPackProvider(IModInfo mod) {
         this.mod = mod;
     }
 
     @Override
     public @Nullable ContentPack providePack() {
-        return mod.getFilePaths()
-            .stream()
-            .map(this::scanSingle)
-            .filter(Objects::nonNull)
-            .findFirst()
-            .orElse(null);
+        var path = mod.getOwningFile()
+            .getFile()
+            .getFilePath();
+        return scanSingle(path);
     }
 
     private ContentPack scanSingle(Path path) {

--- a/src/main/java/com/whisent/kubeloader/impl/mod/ModContentPackProvider.java
+++ b/src/main/java/com/whisent/kubeloader/impl/mod/ModContentPackProvider.java
@@ -3,6 +3,7 @@ package com.whisent.kubeloader.impl.mod;
 import com.whisent.kubeloader.Kubeloader;
 import com.whisent.kubeloader.definition.ContentPack;
 import com.whisent.kubeloader.definition.ContentPackProvider;
+import com.whisent.kubeloader.mixin.AccessScriptManager;
 import dev.architectury.platform.Mod;
 import dev.latvian.mods.kubejs.script.*;
 import org.jetbrains.annotations.NotNull;
@@ -55,8 +56,9 @@ public class ModContentPackProvider implements ContentPackProvider {
 
             for (var entry : entriesByType.entrySet()) {
                 var type = entry.getKey();
+                var manager = type.manager.get();
                 var pack = new ScriptPack(
-                    type.manager.get(),
+                    manager,
                     new ScriptPackInfo(mod.getModId(), "")
                 );
 
@@ -66,7 +68,7 @@ public class ModContentPackProvider implements ContentPackProvider {
                         var reader = new BufferedReader(new InputStreamReader(file.getInputStream(jarEntry)));
                         return reader.lines().toList();
                     };
-                    pack.scripts.add(new ScriptFile(pack, fileInfo, scriptSource));
+                    ((AccessScriptManager) manager).kubeLoader$loadFile(pack, fileInfo, scriptSource);
                 }
 
                 contentPack.packs.put(type, pack);

--- a/src/main/java/com/whisent/kubeloader/mixin/AccessScriptManager.java
+++ b/src/main/java/com/whisent/kubeloader/mixin/AccessScriptManager.java
@@ -1,0 +1,18 @@
+package com.whisent.kubeloader.mixin;
+
+import dev.latvian.mods.kubejs.script.ScriptFileInfo;
+import dev.latvian.mods.kubejs.script.ScriptManager;
+import dev.latvian.mods.kubejs.script.ScriptPack;
+import dev.latvian.mods.kubejs.script.ScriptSource;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+/**
+ * @author ZZZank
+ */
+@Mixin(value = ScriptManager.class, remap = false)
+public interface AccessScriptManager {
+
+    @Invoker("loadFile")
+    void kubeLoader$loadFile(ScriptPack pack, ScriptFileInfo fileInfo, ScriptSource source);
+}

--- a/src/main/java/com/whisent/kubeloader/mixin/ScriptManagerMixin.java
+++ b/src/main/java/com/whisent/kubeloader/mixin/ScriptManagerMixin.java
@@ -69,30 +69,4 @@ public abstract class ScriptManagerMixin {
     private ScriptManager thiz() {
         return (ScriptManager) (Object) this;
     }
-    private static Path getModJarPath(IModInfo mod) {
-        return mod.getOwningFile()
-                .getFile()
-                .getFilePath();
-    }
-    private static boolean isContentPackFile(JarEntry entry) {
-        return entry.getName().startsWith("contentpack/") &&
-                !entry.isDirectory() &&
-                entry.getName().length() > "contentpack".length() + 1;
-    }
-    @Deprecated
-    private static List<String> countLinesInJarEntry(JarFile jarFile, JarEntry entry) throws IOException {
-        if (entry.isDirectory()) {
-            throw new IllegalArgumentException("JarEntry is a directory and cannot be read as a file.");
-        }
-        try (InputStream inputStream = jarFile.getInputStream(entry);
-             BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
-            String line;
-            var list = new ArrayList<String>();
-            while ((line = reader.readLine()) != null) {
-                list.add(line);
-            }
-            return list;
-        }
-    }
-
 }

--- a/src/main/java/com/whisent/kubeloader/mixin/ScriptManagerMixin.java
+++ b/src/main/java/com/whisent/kubeloader/mixin/ScriptManagerMixin.java
@@ -1,12 +1,10 @@
 package com.whisent.kubeloader.mixin;
 
 import com.whisent.kubeloader.Kubeloader;
-import com.whisent.kubeloader.files.ContentScriptSources;
 import com.whisent.kubeloader.files.FileIO;
-import com.whisent.kubeloader.files.jarFix;
+import com.whisent.kubeloader.impl.ContentPackProviders;
 import dev.latvian.mods.kubejs.KubeJS;
 import dev.latvian.mods.kubejs.script.*;
-import net.minecraftforge.fml.ModList;
 import net.minecraftforge.forgespi.language.IModInfo;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -16,10 +14,11 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.jar.JarEntry;
@@ -29,84 +28,46 @@ import java.util.jar.JarFile;
 
 @Mixin(ScriptManager.class)
 public abstract class ScriptManagerMixin {
-    @Shadow @Final public ScriptType scriptType;
+    @Shadow
+    @Final
+    public ScriptType scriptType;
 
-    @Shadow protected abstract void loadFile(ScriptPack pack, ScriptFileInfo fileInfo, ScriptSource source);
+    @Shadow
+    protected abstract void loadFile(ScriptPack pack, ScriptFileInfo fileInfo, ScriptSource source);
 
-    @Shadow @Final public Map<String, ScriptPack> packs;
-    @Unique
-    private Boolean kubeloader$sign = false;
-    @Inject(method = "load",at = @At("HEAD"),remap = false)
-    private void loadScripts(CallbackInfo ci) {
+    @Shadow
+    @Final
+    public Map<String, ScriptPack> packs;
 
-        if (!kubeloader$sign) {
-
-            if (Objects.equals(this.scriptType.name, "startup")){
-            }
-
+    @Inject(method = "reload", at = @At(value = "INVOKE", target = "Ldev/latvian/mods/kubejs/script/ScriptManager;load()V"), remap = false)
+    private void injectPacks(CallbackInfo ci) {
+        for (var contentPack : ContentPackProviders.getPacks()) {
+            this.packs.put(contentPack.getNamespace(), contentPack.getPack(scriptType));
         }
-    }
 
-
-    @Inject(method = "reload",at =
-    @At(value = "INVOKE", target = "Ldev/latvian/mods/kubejs/script/ScriptManager;load()V"),remap = false)
-    //载入文件夹script
-    private void relaoadMixin(CallbackInfo ci) {
-        FileIO.listDirectories(Kubeloader.PackPath).stream().forEach(namespace -> {
+        //TODO: 把这个也改为 ContentPackProvider
+        FileIO.listDirectories(Kubeloader.PackPath).forEach(namespace -> {
             Path ScriptsPath = Kubeloader.PackPath.resolve(namespace).resolve(this.scriptType.name + "_scripts");
             Kubeloader.LOGGER.debug(ScriptsPath.toString());
-            Kubeloader.LOGGER.info((this.scriptType.name+"脚本正在加载"));
-            ScriptPack pack = new ScriptPack(((ScriptManager)((Object) this)), new ScriptPackInfo(ScriptsPath
-                    .getFileName().toString(), ""));
+            Kubeloader.LOGGER.info("{}脚本正在加载", this.scriptType.name);
+            ScriptPack pack = new ScriptPack(
+                thiz(),
+                new ScriptPackInfo(ScriptsPath.getFileName().toString(), "")
+            );
             Kubeloader.LOGGER.debug(pack.toString());
             KubeJS.loadScripts(pack, ScriptsPath, "");
-            Iterator var2 = pack.info.scripts.iterator();
-            while(var2.hasNext()) {
-                ScriptFileInfo fileInfo = (ScriptFileInfo)var2.next();
-                ScriptSource.FromPath scriptSource = (info) -> {
-                    return ScriptsPath.resolve(info.file);
-                };
+            for (ScriptFileInfo fileInfo : pack.info.scripts) {
+                ScriptSource.FromPath scriptSource = (info) -> ScriptsPath.resolve(info.file);
                 this.loadFile(pack, fileInfo, scriptSource);
             }
-            pack.scripts.sort((Comparator)null);
-            this.packs.put(namespace+this.scriptType.name, pack);
+            pack.scripts.sort(null);
+            this.packs.put(namespace + this.scriptType.name, pack);
         });
     }
-    @Inject(method = "reload",at =
-    @At(value = "INVOKE", target = "Ldev/latvian/mods/kubejs/script/ScriptManager;load()V"),remap = false)
-    //载入模组script
-    private void reloadFromModMixin(CallbackInfo ci) {
-        ModList.get().getMods().forEach(mod -> {
-            try {
-                Path jarPath = getModJarPath(mod);
-                if (jarPath != null) {
-                    Kubeloader.LOGGER.debug("找到模组"+mod);
-                    var pack = new ScriptPack((ScriptManager)((Object) this), new ScriptPackInfo(mod.getModId(), ""));
-                    try (JarFile jar = new JarFile(jarPath.toFile())) {
-                        Enumeration<JarEntry> entries = jar.entries();
-                        while (entries.hasMoreElements()) {
-                            JarEntry entry = entries.nextElement();
-                            Path scriptPath = Path.of("contentpack/"+this.scriptType.name+"_scripts/");
-                            Path entryPath = Path.of(entry.getName());
-                            if (isContentPackFile(entry) && entryPath.startsWith(scriptPath)) {
-                                Kubeloader.LOGGER.info("找到jar内文件");
-                                Kubeloader.LOGGER.info(String.valueOf(entryPath));
-                                pack.info.scripts.add(new ScriptFileInfo(pack.info, entry.getName()));
-                                var scriptSource = (ContentScriptSources.FromMod) info -> new jarFix(jar,entry,this.scriptType);
-                                loadFile(pack,new ScriptFileInfo(pack.info, entry.getName()), scriptSource);
-                            }
-                        }
-                        pack.scripts.sort(null);
-                        packs.put(mod.getModId()+this.scriptType.name, pack);
-                    } catch (IOException e) {
-                        System.err.println("Failed to open JAR: " + jarPath);
-                    }
-                }
-            } catch (Exception e) {
-                System.err.println("Error processing mod: " + mod.getModId());
-                e.printStackTrace();
-            }
-        });
+
+    @Unique
+    private ScriptManager thiz() {
+        return (ScriptManager) (Object) this;
     }
     private static Path getModJarPath(IModInfo mod) {
         return mod.getOwningFile()

--- a/src/main/resources/kubeloader.mixins.json
+++ b/src/main/resources/kubeloader.mixins.json
@@ -5,6 +5,7 @@
   "compatibilityLevel": "JAVA_8",
   "refmap": "kubeloader.refmap.json",
   "mixins": [
+    "AccessScriptManager",
     "ScriptManagerMixin"
   ],
   "client": [


### PR DESCRIPTION
这个PR：
- 添加了表示 ContentPack 及其“提供者” ContentPackProvider 相关定义的接口，具体见 `definition` 包
- 添加了基础的 ContentPackProvider 注册系统，理想情况下，借助 mod、文件夹、压缩包添加 ContentPack 都通过这个注册系统进行。都使用 ContentPackProvider 同一个接口，这样具体实现就不会暴露在外。
    - 每个提供者可以提供一个 ContentPack，或者返回 null 表示没有 ContentPack。
    - 有效的 ContentPack 会被缓存起来以免去在重载时一次又一次收集
- 重写了mod中获取 ContentPack 的过程，现在每个模组都会生成一个 ModContentPackProvider，在 KubeLoader 模组初始化的时候就会注册到先前提到的注册系统中