### PR TITLE
Fixing

### DIFF
--- a/src/main/java/com/whisent/kubeloader/definition/ContentPack.java
+++ b/src/main/java/com/whisent/kubeloader/definition/ContentPack.java
@@ -1,7 +1,6 @@
 package com.whisent.kubeloader.definition;
 
 import dev.latvian.mods.kubejs.script.ScriptPack;
-import dev.latvian.mods.kubejs.script.ScriptType;
 import net.minecraft.resources.ResourceLocation;
 
 /**
@@ -17,9 +16,9 @@ public interface ContentPack {
     /**
      * 留作未来使用，或者可能也没用
      */
-    default String getNamespace(ScriptType type) {
+    default String getNamespace(PackLoadingContext context) {
         return getNamespace();
     }
 
-    ScriptPack getPack(ScriptType type);
+    ScriptPack getPack(PackLoadingContext context);
 }

--- a/src/main/java/com/whisent/kubeloader/definition/ContentPack.java
+++ b/src/main/java/com/whisent/kubeloader/definition/ContentPack.java
@@ -2,6 +2,8 @@ package com.whisent.kubeloader.definition;
 
 import dev.latvian.mods.kubejs.script.ScriptPack;
 import net.minecraft.resources.ResourceLocation;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * 一个 ContentPack 是 KubeJS 脚本（与资源）的集合，提供命名空间（{@link dev.latvian.mods.kubejs.script.ScriptPackInfo#namespace}
@@ -11,14 +13,20 @@ import net.minecraft.resources.ResourceLocation;
  */
 public interface ContentPack {
 
+    @NotNull
     String getNamespace();
 
     /**
      * 留作未来使用，或者可能也没用
      */
+    @NotNull
     default String getNamespace(PackLoadingContext context) {
         return getNamespace();
     }
 
+    /**
+     * 如果该 ContentPack 没有{@link PackLoadingContext#type()} 对应的 {@link ScriptPack}，返回 {@code null}
+     */
+    @Nullable
     ScriptPack getPack(PackLoadingContext context);
 }

--- a/src/main/java/com/whisent/kubeloader/definition/ContentPack.java
+++ b/src/main/java/com/whisent/kubeloader/definition/ContentPack.java
@@ -1,6 +1,7 @@
 package com.whisent.kubeloader.definition;
 
 import dev.latvian.mods.kubejs.script.ScriptPack;
+import dev.latvian.mods.kubejs.script.ScriptPackInfo;
 import net.minecraft.resources.ResourceLocation;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -29,4 +30,8 @@ public interface ContentPack {
      */
     @Nullable
     ScriptPack getPack(PackLoadingContext context);
+
+    default ScriptPack createEmptyPack(PackLoadingContext context) {
+        return new ScriptPack(context.manager(), new ScriptPackInfo(getNamespace(context), ""));
+    }
 }

--- a/src/main/java/com/whisent/kubeloader/definition/ContentPackProvider.java
+++ b/src/main/java/com/whisent/kubeloader/definition/ContentPackProvider.java
@@ -8,6 +8,16 @@ import org.jetbrains.annotations.Nullable;
 public interface ContentPackProvider {
 
     /**
+     * 所谓“动态”也就是每次调用{@link #providePack()}的时候，可能会返回不同的结果。非动态的ContentPackProvider返回的结果
+     * 会被缓存以免去重复收集
+     * <p>
+     * 这里假定如无特地更改，ContentPackProvider都是动态的
+     */
+    default boolean isDynamic() {
+        return true;
+    }
+
+    /**
      * @return 该 ContentPackProvider 所提供的 ContentPack，或者，如果其没有，则返回 {@code null}
      */
     @Nullable

--- a/src/main/java/com/whisent/kubeloader/definition/PackLoadingContext.java
+++ b/src/main/java/com/whisent/kubeloader/definition/PackLoadingContext.java
@@ -1,0 +1,28 @@
+package com.whisent.kubeloader.definition;
+
+import com.whisent.kubeloader.mixin.AccessScriptManager;
+import dev.latvian.mods.kubejs.script.*;
+
+/**
+ * @author ZZZank
+ */
+public class PackLoadingContext {
+    private final ScriptManager manager;
+
+    public PackLoadingContext(ScriptManager manager) {
+        this.manager = manager;
+    }
+
+    public ScriptType type() {
+        return manager.scriptType;
+    }
+
+    public ScriptManager manager() {
+        return manager;
+    }
+
+    public void loadFile(ScriptPack pack, ScriptFileInfo fileInfo, ScriptSource source) {
+        var access = (AccessScriptManager) manager;
+        access.kubeLoader$loadFile(pack, fileInfo, source);
+    }
+}

--- a/src/main/java/com/whisent/kubeloader/definition/PackLoadingContext.java
+++ b/src/main/java/com/whisent/kubeloader/definition/PackLoadingContext.java
@@ -8,13 +8,19 @@ import dev.latvian.mods.kubejs.script.*;
  */
 public class PackLoadingContext {
     private final ScriptManager manager;
+    private final String folderName;
 
     public PackLoadingContext(ScriptManager manager) {
         this.manager = manager;
+        this.folderName = type().name + "_scripts";
     }
 
     public ScriptType type() {
         return manager.scriptType;
+    }
+
+    public String folderName() {
+        return folderName;
     }
 
     public ScriptManager manager() {

--- a/src/main/java/com/whisent/kubeloader/impl/ContentPackProviders.java
+++ b/src/main/java/com/whisent/kubeloader/impl/ContentPackProviders.java
@@ -12,27 +12,40 @@ import java.util.Objects;
  * @author ZZZank
  */
 public final class ContentPackProviders {
-    private static final List<ContentPackProvider> PROVIDERS = new ArrayList<>();
     private static List<ContentPack> cachedPacks = null;
+    private static final List<ContentPackProvider> STATIC_PROVIDERS = new ArrayList<>();
+    private static final List<ContentPackProvider> DYNAMIC_PROVIDERS = new ArrayList<>();
 
     public static void register(ContentPackProvider... providers) {
         for (var provider : providers) {
-            PROVIDERS.add(Objects.requireNonNull(provider));
+            if (provider.isDynamic()) {
+                DYNAMIC_PROVIDERS.add(provider);
+            } else {
+                STATIC_PROVIDERS.add(provider);
+            }
         }
     }
 
-    public static List<ContentPackProvider> getProviders() {
-        return Collections.unmodifiableList(PROVIDERS);
+    public static List<ContentPackProvider> getDynamicProviders() {
+        return Collections.unmodifiableList(DYNAMIC_PROVIDERS);
+    }
+
+    public static List<ContentPackProvider> getStaticProviders() {
+        return Collections.unmodifiableList(STATIC_PROVIDERS);
     }
 
     public static List<ContentPack> getPacks() {
         if (cachedPacks == null) {
-            cachedPacks = PROVIDERS
+            cachedPacks = STATIC_PROVIDERS
                 .stream()
                 .map(ContentPackProvider::providePack)
                 .filter(Objects::nonNull)
                 .toList();
         }
-        return cachedPacks;
+        var packs = new ArrayList<>(cachedPacks);
+        for (var provider : DYNAMIC_PROVIDERS) {
+            packs.add(provider.providePack());
+        }
+        return packs;
     }
 }

--- a/src/main/java/com/whisent/kubeloader/impl/mod/ModContentPack.java
+++ b/src/main/java/com/whisent/kubeloader/impl/mod/ModContentPack.java
@@ -20,7 +20,7 @@ import java.util.jar.JarFile;
  */
 public class ModContentPack implements ContentPack {
     private final IModInfo mod;
-    final Map<ScriptType, ScriptPack> packs = new EnumMap<>(ScriptType.class);
+    private final Map<ScriptType, ScriptPack> packs = new EnumMap<>(ScriptType.class);
 
     public ModContentPack(IModInfo mod) {
         this.mod = mod;
@@ -38,10 +38,7 @@ public class ModContentPack implements ContentPack {
     }
 
     private ScriptPack createPack(PackLoadingContext context) {
-        var pack = new ScriptPack(
-            context.manager(),
-            new ScriptPackInfo(mod.getModId(), "")
-        );
+        var pack = createEmptyPack(context);
 
         var prefix = Kubeloader.FOLDER_NAME + '/' + context.folderName() + '/';
         try (var file = new JarFile(mod.getOwningFile().getFile().getFilePath().toFile())) {

--- a/src/main/java/com/whisent/kubeloader/impl/mod/ModContentPack.java
+++ b/src/main/java/com/whisent/kubeloader/impl/mod/ModContentPack.java
@@ -1,13 +1,17 @@
 package com.whisent.kubeloader.impl.mod;
 
+import com.whisent.kubeloader.Kubeloader;
 import com.whisent.kubeloader.definition.ContentPack;
 import com.whisent.kubeloader.definition.PackLoadingContext;
-import dev.latvian.mods.kubejs.script.ScriptPack;
-import dev.latvian.mods.kubejs.script.ScriptType;
+import dev.latvian.mods.kubejs.script.*;
 import net.minecraftforge.forgespi.language.IModInfo;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
 import java.util.EnumMap;
 import java.util.Map;
+import java.util.jar.JarFile;
 
 /**
  * @author ZZZank
@@ -27,6 +31,36 @@ public class ModContentPack implements ContentPack {
 
     @Override
     public ScriptPack getPack(PackLoadingContext context) {
-        return packs.get(context.type());
+        return packs.computeIfAbsent(context.type(), k -> createPack(context));
+    }
+
+    private ScriptPack createPack(PackLoadingContext context) {
+        var pack = new ScriptPack(
+            context.manager(),
+            new ScriptPackInfo(mod.getModId(), "")
+        );
+
+        var prefix = Kubeloader.FOLDER_NAME + '/' + context.folderName() + '/';
+        try (var file = new JarFile(mod.getOwningFile().getFile().getFilePath().toFile())) {
+            var parent = file.getEntry(Kubeloader.FOLDER_NAME + '/' + context.folderName());
+            if (parent == null || !parent.isDirectory()) {
+                return null;
+            }
+            file.stream()
+                .filter(e -> !e.isDirectory())
+                .filter(e -> e.getName().endsWith(".js"))
+                .filter(e -> e.getName().startsWith(prefix))
+                .forEach(jarEntry -> {
+                    var fileInfo = new ScriptFileInfo(pack.info, jarEntry.getName());
+                    var scriptSource = (ScriptSource) info -> {
+                        var reader = new BufferedReader(new InputStreamReader(file.getInputStream(jarEntry)));
+                        return reader.lines().toList();
+                    };
+                    context.loadFile(pack, fileInfo, scriptSource);
+                });
+        } catch (IOException e) {
+            return null;
+        }
+        return pack;
     }
 }

--- a/src/main/java/com/whisent/kubeloader/impl/mod/ModContentPack.java
+++ b/src/main/java/com/whisent/kubeloader/impl/mod/ModContentPack.java
@@ -5,6 +5,8 @@ import com.whisent.kubeloader.definition.ContentPack;
 import com.whisent.kubeloader.definition.PackLoadingContext;
 import dev.latvian.mods.kubejs.script.*;
 import net.minecraftforge.forgespi.language.IModInfo;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -25,11 +27,12 @@ public class ModContentPack implements ContentPack {
     }
 
     @Override
-    public String getNamespace() {
+    public @NotNull String getNamespace() {
         return mod.getModId();
     }
 
     @Override
+    @Nullable
     public ScriptPack getPack(PackLoadingContext context) {
         return packs.computeIfAbsent(context.type(), k -> createPack(context));
     }

--- a/src/main/java/com/whisent/kubeloader/impl/mod/ModContentPack.java
+++ b/src/main/java/com/whisent/kubeloader/impl/mod/ModContentPack.java
@@ -1,6 +1,7 @@
 package com.whisent.kubeloader.impl.mod;
 
 import com.whisent.kubeloader.definition.ContentPack;
+import com.whisent.kubeloader.definition.PackLoadingContext;
 import dev.latvian.mods.kubejs.script.ScriptPack;
 import dev.latvian.mods.kubejs.script.ScriptType;
 import net.minecraftforge.forgespi.language.IModInfo;
@@ -25,7 +26,7 @@ public class ModContentPack implements ContentPack {
     }
 
     @Override
-    public ScriptPack getPack(ScriptType type) {
-        return packs.get(type);
+    public ScriptPack getPack(PackLoadingContext context) {
+        return packs.get(context.type());
     }
 }

--- a/src/main/java/com/whisent/kubeloader/impl/mod/ModContentPackProvider.java
+++ b/src/main/java/com/whisent/kubeloader/impl/mod/ModContentPackProvider.java
@@ -3,19 +3,15 @@ package com.whisent.kubeloader.impl.mod;
 import com.whisent.kubeloader.Kubeloader;
 import com.whisent.kubeloader.definition.ContentPack;
 import com.whisent.kubeloader.definition.ContentPackProvider;
-import com.whisent.kubeloader.mixin.AccessScriptManager;
 import dev.latvian.mods.kubejs.script.*;
 import net.minecraftforge.forgespi.language.IModInfo;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.nio.file.Path;
 import java.util.*;
-import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
+import java.util.zip.ZipEntry;
 
 /**
  * @author ZZZank
@@ -50,55 +46,14 @@ public class ModContentPackProvider implements ContentPackProvider {
 
     private ContentPack scanSingle(Path path) {
         try (var file = new JarFile(path.toFile())) {
-            if (file.getEntry(Kubeloader.FOLDER_NAME) == null) {
+            var entry = file.getEntry(Kubeloader.FOLDER_NAME);
+            if (entry == null || !entry.isDirectory()) {
                 return null;
             }
-
-            var contentPack = new ModContentPack(mod);
-            var entriesByType = collectEntries(file);
-
-            for (var entry : entriesByType.entrySet()) {
-                var type = entry.getKey();
-                var manager = type.manager.get();
-                var pack = new ScriptPack(
-                    manager,
-                    new ScriptPackInfo(mod.getModId(), "")
-                );
-
-                for (var jarEntry : entry.getValue()) {
-                    var fileInfo = new ScriptFileInfo(pack.info, jarEntry.getName());
-                    var scriptSource = (ScriptSource) info -> {
-                        var reader = new BufferedReader(new InputStreamReader(file.getInputStream(jarEntry)));
-                        return reader.lines().toList();
-                    };
-                    ((AccessScriptManager) manager).kubeLoader$loadFile(pack, fileInfo, scriptSource);
-                }
-
-                contentPack.packs.put(type, pack);
-            }
-            return contentPack;
+            return new ModContentPack(mod);
         } catch (IOException e) {
             // log
             return null;
         }
-    }
-
-    private static @NotNull EnumMap<ScriptType, List<JarEntry>> collectEntries(JarFile file) {
-        var entries = file.stream()
-            .filter(e -> !e.isDirectory())
-            .filter(e -> e.getName().endsWith(".js"))
-            .filter(e -> e.getName().startsWith(Kubeloader.FOLDER_NAME + "/"))
-            .toList();
-
-        var entriesByType = new EnumMap<ScriptType, List<JarEntry>>(ScriptType.class);
-        for (var entry : entries) {
-            for (var matcher : PREFIXES.entrySet()) {
-                if (entry.getName().startsWith(matcher.getValue())) {
-                    entriesByType.computeIfAbsent(matcher.getKey(), k -> new ArrayList<>())
-                        .add(entry);
-                }
-            }
-        }
-        return entriesByType;
     }
 }

--- a/src/main/java/com/whisent/kubeloader/impl/mod/ModContentPackProvider.java
+++ b/src/main/java/com/whisent/kubeloader/impl/mod/ModContentPackProvider.java
@@ -36,6 +36,11 @@ public class ModContentPackProvider implements ContentPackProvider {
     }
 
     @Override
+    public boolean isDynamic() {
+        return false;
+    }
+
+    @Override
     public @Nullable ContentPack providePack() {
         var path = mod.getOwningFile()
             .getFile()

--- a/src/main/java/com/whisent/kubeloader/mixin/ScriptManagerMixin.java
+++ b/src/main/java/com/whisent/kubeloader/mixin/ScriptManagerMixin.java
@@ -1,6 +1,7 @@
 package com.whisent.kubeloader.mixin;
 
 import com.whisent.kubeloader.Kubeloader;
+import com.whisent.kubeloader.definition.PackLoadingContext;
 import com.whisent.kubeloader.files.FileIO;
 import com.whisent.kubeloader.impl.ContentPackProviders;
 import dev.latvian.mods.kubejs.KubeJS;
@@ -41,8 +42,9 @@ public abstract class ScriptManagerMixin {
 
     @Inject(method = "reload", at = @At(value = "INVOKE", target = "Ldev/latvian/mods/kubejs/script/ScriptManager;load()V"), remap = false)
     private void injectPacks(CallbackInfo ci) {
+        var context = new PackLoadingContext(thiz());
         for (var contentPack : ContentPackProviders.getPacks()) {
-            this.packs.put(contentPack.getNamespace(), contentPack.getPack(scriptType));
+            this.packs.put(contentPack.getNamespace(context), contentPack.getPack(context));
         }
 
         //TODO: 把这个也改为 ContentPackProvider

--- a/src/main/java/com/whisent/kubeloader/mixin/ScriptManagerMixin.java
+++ b/src/main/java/com/whisent/kubeloader/mixin/ScriptManagerMixin.java
@@ -44,7 +44,10 @@ public abstract class ScriptManagerMixin {
     private void injectPacks(CallbackInfo ci) {
         var context = new PackLoadingContext(thiz());
         for (var contentPack : ContentPackProviders.getPacks()) {
-            this.packs.put(contentPack.getNamespace(context), contentPack.getPack(context));
+            var pack = contentPack.getPack(context);
+            if (pack != null) {
+                this.packs.put(contentPack.getNamespace(context), pack);
+            }
         }
 
         //TODO: 把这个也改为 ContentPackProvider


### PR DESCRIPTION
昨晚写代码时脑子不甚清醒，现在发现写出的API里有几个问题：
- KubeLoader 未来肯定会支持从文件夹与zip里加载ContentPack，这两个来源都不保证能提供的ContentPack一直一样。比如添加了文件或是内容有所修改都是改变了ContentPack的内容
- ModContentPack 会在初始化时加载所有3个ScriptType的内容，但实际上3个ScriptType加载脚本的时间是错开的
- ModContentPack 如果加载时出现错误就会返回null表示无效，但是这时，这个null依然会进入ScriptManager，破坏后续加载

所以：
- 添加了 `ContentPackProvider.isDynamic()` 判断其是不是动态的，只有非动态的 ContentPackProvider 提供的 ContentPack 才会被缓存
- 将 ModContentPack 的加载移动到了请求，如果提供的脚本类型对应的脚本没有加载，则会通过 `ModContentPack.createPack(...)` 加载
- 在注入脚本的时候添加了一个 null 过滤