### PR TITLE
allow one provider to provide multiple packs

### DIFF
--- a/src/main/java/com/whisent/kubeloader/Kubeloader.java
+++ b/src/main/java/com/whisent/kubeloader/Kubeloader.java
@@ -67,7 +67,7 @@ public class Kubeloader {
             .getMods()
             .stream()
             .map(ModContentPackProvider::new)
-            .toArray(ContentPackProvider[]::new);
+            .toList();
         ContentPackProviders.register(providers);
     }
 
@@ -79,8 +79,7 @@ public class Kubeloader {
             ZipContentPackProvider zipContentPackProvider = new ZipContentPackProvider(file);
             list.add(zipContentPackProvider);
         }
-        var providers = list.toArray(new ContentPackProvider[0]);
-        ContentPackProviders.register(providers);
+        ContentPackProviders.register(list);
     }
 
 

--- a/src/main/java/com/whisent/kubeloader/definition/ContentPackProvider.java
+++ b/src/main/java/com/whisent/kubeloader/definition/ContentPackProvider.java
@@ -1,6 +1,8 @@
 package com.whisent.kubeloader.definition;
 
-import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
 
 /**
  * @author ZZZank
@@ -18,8 +20,8 @@ public interface ContentPackProvider {
     }
 
     /**
-     * @return 该 ContentPackProvider 所提供的 ContentPack，或者，如果其没有，则返回 {@code null}
+     * @return 该 ContentPackProvider 所提供的 ContentPack，或者，如果其没有，返回一个空集合
      */
-    @Nullable
-    ContentPack providePack();
+    @NotNull
+    Collection<? extends ContentPack> providePack();
 }

--- a/src/main/java/com/whisent/kubeloader/definition/ContentPackProvider.java
+++ b/src/main/java/com/whisent/kubeloader/definition/ContentPackProvider.java
@@ -23,5 +23,5 @@ public interface ContentPackProvider {
      * @return 该 ContentPackProvider 所提供的 ContentPack，或者，如果其没有，返回一个空集合
      */
     @NotNull
-    Collection<? extends ContentPack> providePack();
+    Collection<? extends @NotNull ContentPack> providePack();
 }

--- a/src/main/java/com/whisent/kubeloader/impl/ContentPackProviders.java
+++ b/src/main/java/com/whisent/kubeloader/impl/ContentPackProviders.java
@@ -4,16 +4,13 @@ import com.whisent.kubeloader.Kubeloader;
 import com.whisent.kubeloader.definition.ContentPack;
 import com.whisent.kubeloader.definition.ContentPackProvider;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 
 /**
  * @author ZZZank
  */
 public final class ContentPackProviders {
-    private static List<ContentPack> cachedPacks = null;
+    private static List<? extends ContentPack> cachedPacks = null;
     private static final List<ContentPackProvider> STATIC_PROVIDERS = new ArrayList<>();
     private static final List<ContentPackProvider> DYNAMIC_PROVIDERS = new ArrayList<>();
 
@@ -41,13 +38,14 @@ public final class ContentPackProviders {
             cachedPacks = STATIC_PROVIDERS
                 .stream()
                 .map(ContentPackProvider::providePack)
+                .flatMap(Collection::stream)
                 .filter(Objects::nonNull)
                 .toList();
         }
-        var packs = new ArrayList<>(cachedPacks);
+        var packs = new ArrayList<ContentPack>(cachedPacks);
         for (var provider : DYNAMIC_PROVIDERS) {
             Kubeloader.LOGGER.debug("尝试添加Pack"+provider);
-            packs.add(provider.providePack());
+            packs.addAll(provider.providePack());
         }
         return packs;
     }

--- a/src/main/java/com/whisent/kubeloader/impl/ContentPackProviders.java
+++ b/src/main/java/com/whisent/kubeloader/impl/ContentPackProviders.java
@@ -17,9 +17,10 @@ public final class ContentPackProviders {
     public static void register(ContentPackProvider... providers) {
         for (var provider : providers) {
             if (provider.isDynamic()) {
-                Kubeloader.LOGGER.debug("增加了动态Provider"+provider);
+                Kubeloader.LOGGER.debug("增加了动态Provider: {}", provider);
                 DYNAMIC_PROVIDERS.add(provider);
             } else {
+                Kubeloader.LOGGER.debug("增加了静态Provider: {}", provider);
                 STATIC_PROVIDERS.add(provider);
             }
         }
@@ -44,7 +45,7 @@ public final class ContentPackProviders {
         }
         var packs = new ArrayList<ContentPack>(cachedPacks);
         for (var provider : DYNAMIC_PROVIDERS) {
-            Kubeloader.LOGGER.debug("尝试添加Pack"+provider);
+            Kubeloader.LOGGER.debug("尝试添加Pack: {}", provider);
             packs.addAll(provider.providePack());
         }
         return packs;

--- a/src/main/java/com/whisent/kubeloader/impl/ContentPackProviders.java
+++ b/src/main/java/com/whisent/kubeloader/impl/ContentPackProviders.java
@@ -14,7 +14,7 @@ public final class ContentPackProviders {
     private static final List<ContentPackProvider> STATIC_PROVIDERS = new ArrayList<>();
     private static final List<ContentPackProvider> DYNAMIC_PROVIDERS = new ArrayList<>();
 
-    public static void register(ContentPackProvider... providers) {
+    public static void register(Collection<? extends ContentPackProvider> providers) {
         for (var provider : providers) {
             if (provider.isDynamic()) {
                 Kubeloader.LOGGER.debug("增加了动态Provider: {}", provider);
@@ -24,6 +24,10 @@ public final class ContentPackProviders {
                 STATIC_PROVIDERS.add(provider);
             }
         }
+    }
+
+    public static void register(ContentPackProvider... providers) {
+        register(Arrays.asList(providers));
     }
 
     public static List<ContentPackProvider> getDynamicProviders() {

--- a/src/main/java/com/whisent/kubeloader/impl/mod/ModContentPack.java
+++ b/src/main/java/com/whisent/kubeloader/impl/mod/ModContentPack.java
@@ -63,4 +63,9 @@ public class ModContentPack implements ContentPack {
         }
         return pack;
     }
+
+    @Override
+    public String toString() {
+        return "ModContentPack[mod=%s]".formatted(mod.getModId());
+    }
 }

--- a/src/main/java/com/whisent/kubeloader/impl/mod/ModContentPackProvider.java
+++ b/src/main/java/com/whisent/kubeloader/impl/mod/ModContentPackProvider.java
@@ -36,7 +36,7 @@ public class ModContentPackProvider implements ContentPackProvider {
     }
 
     @Override
-    public @NotNull Collection<? extends ContentPack> providePack() {
+    public @NotNull Collection<? extends @NotNull ContentPack> providePack() {
         var path = mod.getOwningFile()
             .getFile()
             .getFilePath();
@@ -55,5 +55,10 @@ public class ModContentPackProvider implements ContentPackProvider {
             // log
             return null;
         }
+    }
+
+    @Override
+    public String toString() {
+        return "ModContentPackProvider[mod=%s]".formatted(mod.getModId());
     }
 }

--- a/src/main/java/com/whisent/kubeloader/impl/mod/ModContentPackProvider.java
+++ b/src/main/java/com/whisent/kubeloader/impl/mod/ModContentPackProvider.java
@@ -5,13 +5,12 @@ import com.whisent.kubeloader.definition.ContentPack;
 import com.whisent.kubeloader.definition.ContentPackProvider;
 import dev.latvian.mods.kubejs.script.*;
 import net.minecraftforge.forgespi.language.IModInfo;
-import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.jar.JarFile;
-import java.util.zip.ZipEntry;
 
 /**
  * @author ZZZank
@@ -37,11 +36,12 @@ public class ModContentPackProvider implements ContentPackProvider {
     }
 
     @Override
-    public @Nullable ContentPack providePack() {
+    public @NotNull Collection<? extends ContentPack> providePack() {
         var path = mod.getOwningFile()
             .getFile()
             .getFilePath();
-        return scanSingle(path);
+        var got = scanSingle(path);
+        return got == null ? List.of() : List.of(got);
     }
 
     private ContentPack scanSingle(Path path) {

--- a/src/main/java/com/whisent/kubeloader/impl/mod/ModContentPackProvider.java
+++ b/src/main/java/com/whisent/kubeloader/impl/mod/ModContentPackProvider.java
@@ -16,13 +16,6 @@ import java.util.jar.JarFile;
  * @author ZZZank
  */
 public class ModContentPackProvider implements ContentPackProvider {
-    private static final Map<ScriptType, String> PREFIXES = new EnumMap<>(ScriptType.class);
-
-    static {
-        for (var scriptType : ScriptType.values()) {
-            PREFIXES.put(scriptType, Kubeloader.FOLDER_NAME + '/' + scriptType.name + '/');
-        }
-    }
 
     private final IModInfo mod;
 

--- a/src/main/java/com/whisent/kubeloader/impl/zip/ZipContentPack.java
+++ b/src/main/java/com/whisent/kubeloader/impl/zip/ZipContentPack.java
@@ -23,16 +23,22 @@ import java.util.zip.ZipFile;
 
 public class ZipContentPack implements ContentPack {
     private final ZipFile zipFile;
-    private final String namespace;
+    private String namespace;
     private final Map<ScriptType, ScriptPack> packs = new EnumMap<>(ScriptType.class);
 
     public ZipContentPack(File file) throws IOException {
         this.zipFile = new ZipFile(file);
-        this.namespace = getNamespace();
     }
 
     @Override
     public @NotNull String getNamespace() {
+        if (namespace == null) {
+            namespace = computeNamespace();
+        }
+        return namespace;
+    }
+
+    private String computeNamespace() {
         Set<String> firstLevelFolders = zipFile.stream()
                 .map(ZipEntry::getName)
                 .filter(name -> name.endsWith("/"))

--- a/src/main/java/com/whisent/kubeloader/impl/zip/ZipContentPack.java
+++ b/src/main/java/com/whisent/kubeloader/impl/zip/ZipContentPack.java
@@ -49,7 +49,7 @@ public class ZipContentPack implements ContentPack {
             Kubeloader.LOGGER.debug(firstLevelFolders.toString());
             return "";
         } else {
-            Kubeloader.LOGGER.debug("获取namespace为"+firstLevelFolders.iterator().next().split("/")[0]);
+            Kubeloader.LOGGER.debug("获取namespace为{}", firstLevelFolders.iterator().next().split("/")[0]);
             return firstLevelFolders.iterator().next().split("/")[0];
         }
     }
@@ -84,5 +84,10 @@ public class ZipContentPack implements ContentPack {
                         context.loadFile(pack,zipFileInfo,scriptSource);
                     });
         return pack;
-    };
+    }
+
+    @Override
+    public String toString() {
+        return "ZipContentPack[namespace=%s]".formatted(getNamespace());
+    }
 }

--- a/src/main/java/com/whisent/kubeloader/impl/zip/ZipContentPackProvider.java
+++ b/src/main/java/com/whisent/kubeloader/impl/zip/ZipContentPackProvider.java
@@ -1,15 +1,15 @@
 package com.whisent.kubeloader.impl.zip;
 
-import com.whisent.kubeloader.Kubeloader;
 import com.whisent.kubeloader.definition.ContentPack;
 import com.whisent.kubeloader.definition.ContentPackProvider;
-import com.whisent.kubeloader.impl.mod.ModContentPack;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Path;
+import java.util.Collection;
 import java.util.Enumeration;
+import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
@@ -23,15 +23,12 @@ public class ZipContentPackProvider  implements ContentPackProvider {
     }
 
     @Override
-    public boolean isDynamic() {
-        return true;
+    public @NotNull Collection<? extends ContentPack> providePack() {
+        var got = scanSingle(zipFile);
+        return got == null ? List.of() : List.of(got);
     }
 
-    @Override
-    public @Nullable ContentPack providePack() {
-        return scanSingle(zipFile);
-    }
-
+    @Nullable
     private ContentPack scanSingle(ZipFile zipFile) {
         try {
             Enumeration<? extends ZipEntry> entries = zipFile.entries();

--- a/src/main/java/com/whisent/kubeloader/impl/zip/ZipContentPackProvider.java
+++ b/src/main/java/com/whisent/kubeloader/impl/zip/ZipContentPackProvider.java
@@ -23,7 +23,7 @@ public class ZipContentPackProvider  implements ContentPackProvider {
     }
 
     @Override
-    public @NotNull Collection<? extends ContentPack> providePack() {
+    public @NotNull Collection<? extends @NotNull ContentPack> providePack() {
         var got = scanSingle(zipFile);
         return got == null ? List.of() : List.of(got);
     }

--- a/src/main/java/com/whisent/kubeloader/mixin/ScriptManagerMixin.java
+++ b/src/main/java/com/whisent/kubeloader/mixin/ScriptManagerMixin.java
@@ -45,7 +45,7 @@ public abstract class ScriptManagerMixin {
     private void injectPacks(CallbackInfo ci) {
         var context = new PackLoadingContext(thiz());
         for (var contentPack : ContentPackProviders.getPacks()) {
-            Kubeloader.LOGGER.debug("寻找到contentPack: " + contentPack);
+            Kubeloader.LOGGER.debug("寻找到contentPack: {}", contentPack);
             var pack = contentPack.getPack(context);
             if (pack != null) {
                 this.packs.put(contentPack.getNamespace(context), pack);


### PR DESCRIPTION
通过zip或者contentpacks文件夹添加ContentPack暴露了先前设计的另一个问题：压缩包的数量与contentpacks文件夹里ContentPack都是可以变化的，如果provider注册仍只在初始化时进行一次，且每个provider只能提供一个ContentPack，那添加/删减ContentPack之后就必须重启游戏

因此：
- `ContentPackProvider#providePack()` 的返回值改为了一个集合，允许ContentPackProvider提供任意多个ContentPack
- 稍微修改了日志记录，让涉及到ContentPack与ContentPackProvider的日志稍微更可读了一些

代码设计总是免不了后见之明¯\\\_(ツ)\_/¯