### PR TITLE
Standardized ContentPack initialization

### DIFF
--- a/src/main/java/com/whisent/kubeloader/Kubeloader.java
+++ b/src/main/java/com/whisent/kubeloader/Kubeloader.java
@@ -76,7 +76,7 @@ public class Kubeloader {
             //path
             new PathContentPackProvider(PackPath),
             //kubejs dummy, for sorting content packs
-            new DummyContentPackProvider(List.of(new DummyContentPack(KubeJS.MOD_ID, Map.of())))
+            new DummyContentPackProvider(List.of(new DummyContentPack(KubeJS.MOD_ID, cx -> null)))
         );
     }
 

--- a/src/main/java/com/whisent/kubeloader/Kubeloader.java
+++ b/src/main/java/com/whisent/kubeloader/Kubeloader.java
@@ -22,17 +22,14 @@ import net.minecraftforge.fml.ModList;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
-import net.minecraftforge.fml.loading.FMLPaths;
 import org.slf4j.Logger;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 @Mod(Kubeloader.MODID)
 public class Kubeloader {
@@ -70,11 +67,11 @@ public class Kubeloader {
 
         //mod
         //registerModContentPackProviders();
-        //zip
-        registerZipContentPackProviders();
         ContentPackProviders.register(
             //path
             new PathContentPackProvider(PackPath),
+            // zip
+            new ZipContentPackProvider(PackPath),
             //kubejs dummy, for sorting content packs
             new DummyContentPackProvider(List.of(new DummyContentPack(KubeJS.MOD_ID, cx -> null)))
         );
@@ -89,18 +86,6 @@ public class Kubeloader {
             .toList();
         ContentPackProviders.register(providers);
     }
-
-    private static void registerZipContentPackProviders() throws IOException {
-        List<ZipContentPackProvider> list = new ArrayList<>();
-        for (String s : FileIO.listZips(PackPath)) {
-            Kubeloader.LOGGER.debug("找到压缩包："+s);
-            File file = new File(s);
-            ZipContentPackProvider zipContentPackProvider = new ZipContentPackProvider(file);
-            list.add(zipContentPackProvider);
-        }
-        ContentPackProviders.register(list);
-    }
-
 
     private void ModLoding(FMLClientSetupEvent event) {
         LOGGER.info("Setup启动事件");

--- a/src/main/java/com/whisent/kubeloader/definition/ContentPack.java
+++ b/src/main/java/com/whisent/kubeloader/definition/ContentPack.java
@@ -1,19 +1,10 @@
 package com.whisent.kubeloader.definition;
 
-import com.google.gson.JsonObject;
-import com.mojang.serialization.DataResult;
-import com.mojang.serialization.JsonOps;
-import com.whisent.kubeloader.Kubeloader;
 import com.whisent.kubeloader.definition.meta.PackMetaData;
-import com.whisent.kubeloader.files.FileIO;
 import dev.latvian.mods.kubejs.script.ScriptPack;
-import dev.latvian.mods.kubejs.script.ScriptPackInfo;
 import net.minecraft.resources.ResourceLocation;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import java.io.IOException;
-import java.io.InputStream;
 
 /**
  * 一个 ContentPack 是 KubeJS 脚本（与资源）的集合，提供命名空间（{@link dev.latvian.mods.kubejs.script.ScriptPackInfo#namespace}
@@ -40,26 +31,5 @@ public interface ContentPack {
     default ScriptPack postProcessPack(PackLoadingContext context, @NotNull ScriptPack pack) {
         pack.scripts.sort(null);
         return pack;
-    }
-
-    static ScriptPack createEmptyPack(PackLoadingContext context, String id) {
-        return new ScriptPack(context.manager(), new ScriptPackInfo(id, ""));
-    }
-
-    static DataResult<PackMetaData> loadMetaData(InputStream stream) {
-        try (var reader = FileIO.stream2reader(stream)) {
-            var json = Kubeloader.GSON.fromJson(reader, JsonObject.class);
-            return PackMetaData.CODEC.parse(JsonOps.INSTANCE, json);
-        } catch (IOException e) {
-            return DataResult.error(e::toString);
-        }
-    }
-
-    static PackMetaData loadMetaDataOrThrow(InputStream stream) {
-        var result = loadMetaData(stream);
-        if (result.error().isPresent()) {
-            throw new RuntimeException(result.error().get().message());
-        }
-        return result.result().orElseThrow();
     }
 }

--- a/src/main/java/com/whisent/kubeloader/definition/ContentPack.java
+++ b/src/main/java/com/whisent/kubeloader/definition/ContentPack.java
@@ -1,11 +1,19 @@
 package com.whisent.kubeloader.definition;
 
+import com.google.gson.JsonObject;
+import com.mojang.serialization.DataResult;
+import com.mojang.serialization.JsonOps;
+import com.whisent.kubeloader.Kubeloader;
 import com.whisent.kubeloader.definition.meta.PackMetaData;
+import com.whisent.kubeloader.files.FileIO;
 import dev.latvian.mods.kubejs.script.ScriptPack;
 import dev.latvian.mods.kubejs.script.ScriptPackInfo;
 import net.minecraft.resources.ResourceLocation;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.io.IOException;
+import java.io.InputStream;
 
 /**
  * 一个 ContentPack 是 KubeJS 脚本（与资源）的集合，提供命名空间（{@link dev.latvian.mods.kubejs.script.ScriptPackInfo#namespace}
@@ -34,7 +42,24 @@ public interface ContentPack {
         return pack;
     }
 
-    default ScriptPack createEmptyPack(PackLoadingContext context) {
-        return new ScriptPack(context.manager(), new ScriptPackInfo(id(), ""));
+    static ScriptPack createEmptyPack(PackLoadingContext context, String id) {
+        return new ScriptPack(context.manager(), new ScriptPackInfo(id, ""));
+    }
+
+    static DataResult<PackMetaData> loadMetaData(InputStream stream) {
+        try (var reader = FileIO.stream2reader(stream)) {
+            var json = Kubeloader.GSON.fromJson(reader, JsonObject.class);
+            return PackMetaData.CODEC.parse(JsonOps.INSTANCE, json);
+        } catch (IOException e) {
+            return DataResult.error(e::toString);
+        }
+    }
+
+    static PackMetaData loadMetaDataOrThrow(InputStream stream) {
+        var result = loadMetaData(stream);
+        if (result.error().isPresent()) {
+            throw new RuntimeException(result.error().get().message());
+        }
+        return result.result().orElseThrow();
     }
 }

--- a/src/main/java/com/whisent/kubeloader/definition/ContentPack.java
+++ b/src/main/java/com/whisent/kubeloader/definition/ContentPack.java
@@ -15,20 +15,7 @@ import org.jetbrains.annotations.Nullable;
  */
 public interface ContentPack {
 
-    @NotNull
-    String getNamespace();
-
-    /**
-     * 留作未来使用，或者可能也没用
-     */
-    @NotNull
-    default String getNamespace(PackLoadingContext context) {
-        return getNamespace();
-    }
-
-    default PackMetaData getMetaData() {
-        return PackMetaData.minimal(getNamespace());
-    }
+    PackMetaData getMetaData();
 
     /**
      * 如果该 ContentPack 没有{@link PackLoadingContext#type()} 对应的 {@link ScriptPack}，返回 {@code null}
@@ -37,12 +24,17 @@ public interface ContentPack {
     ScriptPack getPack(PackLoadingContext context);
 
     @NotNull
+    default String id() {
+        return this.getMetaData().id();
+    }
+
+    @NotNull
     default ScriptPack postProcessPack(PackLoadingContext context, @NotNull ScriptPack pack) {
         pack.scripts.sort(null);
         return pack;
     }
 
     default ScriptPack createEmptyPack(PackLoadingContext context) {
-        return new ScriptPack(context.manager(), new ScriptPackInfo(getNamespace(context), ""));
+        return new ScriptPack(context.manager(), new ScriptPackInfo(id(), ""));
     }
 }

--- a/src/main/java/com/whisent/kubeloader/definition/ContentPackUtils.java
+++ b/src/main/java/com/whisent/kubeloader/definition/ContentPackUtils.java
@@ -4,6 +4,7 @@ import com.google.gson.JsonObject;
 import com.mojang.serialization.DataResult;
 import com.mojang.serialization.JsonOps;
 import com.whisent.kubeloader.Kubeloader;
+import com.whisent.kubeloader.definition.meta.dependency.DependencySource;
 import com.whisent.kubeloader.impl.depends.ImmutableMetaData;
 import com.whisent.kubeloader.definition.meta.PackMetaData;
 import com.whisent.kubeloader.definition.meta.dependency.DependencyType;
@@ -62,6 +63,7 @@ public class ContentPackUtils {
     public static PackDependency dependencyFromMod(IModInfo.ModVersion modDep) {
         return new ImmutableDependency(
             modDep.isMandatory() ? DependencyType.REQUIRED : DependencyType.OPTIONAL,
+            DependencySource.MOD,
             modDep.getModId(),
             Optional.of(modDep.getVersionRange()),
             modDep.getReferralURL().map(URL::toString),

--- a/src/main/java/com/whisent/kubeloader/definition/ContentPackUtils.java
+++ b/src/main/java/com/whisent/kubeloader/definition/ContentPackUtils.java
@@ -1,0 +1,71 @@
+package com.whisent.kubeloader.definition;
+
+import com.google.gson.JsonObject;
+import com.mojang.serialization.DataResult;
+import com.mojang.serialization.JsonOps;
+import com.whisent.kubeloader.Kubeloader;
+import com.whisent.kubeloader.impl.depends.ImmutableMetaData;
+import com.whisent.kubeloader.definition.meta.PackMetaData;
+import com.whisent.kubeloader.definition.meta.dependency.DependencyType;
+import com.whisent.kubeloader.impl.depends.ImmutableDependency;
+import com.whisent.kubeloader.definition.meta.dependency.PackDependency;
+import com.whisent.kubeloader.files.FileIO;
+import dev.latvian.mods.kubejs.script.ScriptPack;
+import dev.latvian.mods.kubejs.script.ScriptPackInfo;
+import net.minecraftforge.forgespi.language.IModInfo;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * @author ZZZank
+ */
+public class ContentPackUtils {
+    public static ScriptPack createEmptyPack(PackLoadingContext context, String id) {
+        return new ScriptPack(context.manager(), new ScriptPackInfo(id, ""));
+    }
+
+    public static DataResult<PackMetaData> loadMetaData(InputStream stream) {
+        try (var reader = FileIO.stream2reader(stream)) {
+            var json = Kubeloader.GSON.fromJson(reader, JsonObject.class);
+            return PackMetaData.CODEC.parse(JsonOps.INSTANCE, json);
+        } catch (IOException e) {
+            return DataResult.error(e::toString);
+        }
+    }
+
+    public static PackMetaData loadMetaDataOrThrow(InputStream stream) {
+        var result = loadMetaData(stream);
+        if (result.error().isPresent()) {
+            throw new RuntimeException(result.error().get().message());
+        }
+        return result.result().orElseThrow();
+    }
+
+    public static PackMetaData metadataFromMod(IModInfo mod) {
+        return new ImmutableMetaData(
+            mod.getModId(),
+            Optional.of(mod.getDisplayName()),
+            Optional.of(mod.getDescription()),
+            Optional.of(mod.getVersion()),
+            List.of(),
+            mod.getDependencies()
+                .stream()
+                .map(ContentPackUtils::dependencyFromMod)
+                .toList()
+        );
+    }
+
+    public static PackDependency dependencyFromMod(IModInfo.ModVersion modDep) {
+        return new ImmutableDependency(
+            modDep.isMandatory() ? DependencyType.REQUIRED : DependencyType.OPTIONAL,
+            modDep.getModId(),
+            Optional.of(modDep.getVersionRange()),
+            modDep.getReferralURL().map(URL::toString),
+            Optional.empty()
+        );
+    }
+}

--- a/src/main/java/com/whisent/kubeloader/definition/meta/PackMetaData.java
+++ b/src/main/java/com/whisent/kubeloader/definition/meta/PackMetaData.java
@@ -3,6 +3,7 @@ package com.whisent.kubeloader.definition.meta;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import com.whisent.kubeloader.definition.meta.dependency.PackDependency;
+import com.whisent.kubeloader.impl.depends.ImmutableMetaData;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 
 import java.util.List;

--- a/src/main/java/com/whisent/kubeloader/definition/meta/dependency/DependencySource.java
+++ b/src/main/java/com/whisent/kubeloader/definition/meta/dependency/DependencySource.java
@@ -1,0 +1,15 @@
+package com.whisent.kubeloader.definition.meta.dependency;
+
+import com.mojang.serialization.Codec;
+import com.whisent.kubeloader.utils.CodecUtil;
+
+/**
+ * @author ZZZank
+ */
+public enum DependencySource {
+    PACK,
+    MOD
+    ;
+
+    public static final Codec<DependencySource> CODEC = CodecUtil.createEnumStringCodec(DependencySource.class);
+}

--- a/src/main/java/com/whisent/kubeloader/definition/meta/dependency/DependencyType.java
+++ b/src/main/java/com/whisent/kubeloader/definition/meta/dependency/DependencyType.java
@@ -27,10 +27,6 @@ public enum DependencyType {
      * 一起运行可能导致崩溃。发现时打断加载。
      */
     INCOMPATIBLE,
-    /**
-     * 需要对应模组才能运行，否则崩溃。
-     */
-    MOD,
     ;
 
     public static final Codec<DependencyType> CODEC = CodecUtil.createEnumStringCodec(DependencyType.class);

--- a/src/main/java/com/whisent/kubeloader/definition/meta/dependency/PackDependency.java
+++ b/src/main/java/com/whisent/kubeloader/definition/meta/dependency/PackDependency.java
@@ -18,6 +18,8 @@ public interface PackDependency {
 
     DependencyType type();
 
+    DependencySource source();
+
     String id();
 
     Optional<VersionRange> versionRange();
@@ -41,8 +43,10 @@ public interface PackDependency {
     Codec<PackDependency> CODEC = RecordCodecBuilder.create(
         builder -> builder.group(
             DependencyType.CODEC.fieldOf("type").forGetter(PackDependency::type),
+            DependencySource.CODEC.optionalFieldOf("source", DependencySource.PACK).forGetter(PackDependency::source),
             Codec.STRING.fieldOf("id").forGetter(PackDependency::id),
-            ImmutableDependency.VERSION_RANGE_CODEC.optionalFieldOf("versionRange").forGetter(PackDependency::versionRange),
+            ImmutableDependency.VERSION_RANGE_CODEC.optionalFieldOf("versionRange")
+                .forGetter(PackDependency::versionRange),
             Codec.STRING.optionalFieldOf("reason").forGetter(PackDependency::reason),
             LoadOrdering.CODEC.optionalFieldOf("ordering").forGetter(PackDependency::ordering)
         ).apply(builder, ImmutableDependency::new)

--- a/src/main/java/com/whisent/kubeloader/definition/meta/dependency/PackDependency.java
+++ b/src/main/java/com/whisent/kubeloader/definition/meta/dependency/PackDependency.java
@@ -30,9 +30,10 @@ public interface PackDependency {
 
     default MutableComponent toReport(ContentPack parent) {
         return Component.translatable(
-            "%s declared %s dependency with id '%s' and version range '%s'%s",
+            "%s declared %s %s dependency with id '%s' and version range '%s'%s",
             Component.literal(parent.toString()).withStyle(ChatFormatting.YELLOW, ChatFormatting.UNDERLINE),
             Component.literal(this.type().toString()),
+            Component.literal(this.source().toString()),
             Component.literal(this.id()).withStyle(ChatFormatting.YELLOW),
             Component.literal(this.versionRange().map(VersionRange::toString).orElse("*"))
                 .withStyle(ChatFormatting.YELLOW),

--- a/src/main/java/com/whisent/kubeloader/definition/meta/dependency/PackDependency.java
+++ b/src/main/java/com/whisent/kubeloader/definition/meta/dependency/PackDependency.java
@@ -3,6 +3,7 @@ package com.whisent.kubeloader.definition.meta.dependency;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import com.whisent.kubeloader.definition.ContentPack;
+import com.whisent.kubeloader.impl.depends.ImmutableDependency;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;

--- a/src/main/java/com/whisent/kubeloader/files/FileIO.java
+++ b/src/main/java/com/whisent/kubeloader/files/FileIO.java
@@ -4,6 +4,7 @@ import com.whisent.kubeloader.Kubeloader;
 import net.minecraft.client.Minecraft;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.List;
@@ -216,5 +217,9 @@ public class FileIO {
             }
         }
         Files.delete(path);
+    }
+
+    public static BufferedReader stream2reader(InputStream stream) {
+        return new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8));
     }
 }

--- a/src/main/java/com/whisent/kubeloader/impl/ContentPackBase.java
+++ b/src/main/java/com/whisent/kubeloader/impl/ContentPackBase.java
@@ -1,0 +1,40 @@
+package com.whisent.kubeloader.impl;
+
+import com.whisent.kubeloader.definition.ContentPack;
+import com.whisent.kubeloader.definition.PackLoadingContext;
+import com.whisent.kubeloader.definition.meta.PackMetaData;
+import dev.latvian.mods.kubejs.script.ScriptPack;
+import dev.latvian.mods.kubejs.script.ScriptType;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * @author ZZZank
+ */
+public abstract class ContentPackBase implements ContentPack {
+    protected final Map<ScriptType, Optional<ScriptPack>> packs = new EnumMap<>(ScriptType.class);
+    protected final PackMetaData metaData;
+
+    protected ContentPackBase(PackMetaData metaData) {
+        this.metaData = metaData;
+    }
+
+    @Nullable
+    protected abstract ScriptPack createPack(PackLoadingContext context);
+
+    @Override
+    public @Nullable ScriptPack getPack(PackLoadingContext context) {
+        return this.packs.computeIfAbsent(
+            context.type(),
+            t -> Optional.ofNullable(createPack(context))
+        ).orElse(null);
+    }
+
+    @Override
+    public PackMetaData getMetaData() {
+        return metaData;
+    }
+}

--- a/src/main/java/com/whisent/kubeloader/impl/depends/ImmutableDependency.java
+++ b/src/main/java/com/whisent/kubeloader/impl/depends/ImmutableDependency.java
@@ -1,6 +1,7 @@
 package com.whisent.kubeloader.impl.depends;
 
 import com.mojang.serialization.Codec;
+import com.whisent.kubeloader.definition.meta.dependency.DependencySource;
 import com.whisent.kubeloader.definition.meta.dependency.DependencyType;
 import com.whisent.kubeloader.definition.meta.dependency.LoadOrdering;
 import com.whisent.kubeloader.definition.meta.dependency.PackDependency;
@@ -14,6 +15,7 @@ import java.util.Optional;
  */
 public record ImmutableDependency(
     DependencyType type,
+    DependencySource source,
     String id,
     Optional<VersionRange> versionRange,
     Optional<String> reason,

--- a/src/main/java/com/whisent/kubeloader/impl/depends/ImmutableDependency.java
+++ b/src/main/java/com/whisent/kubeloader/impl/depends/ImmutableDependency.java
@@ -1,6 +1,9 @@
-package com.whisent.kubeloader.definition.meta.dependency;
+package com.whisent.kubeloader.impl.depends;
 
 import com.mojang.serialization.Codec;
+import com.whisent.kubeloader.definition.meta.dependency.DependencyType;
+import com.whisent.kubeloader.definition.meta.dependency.LoadOrdering;
+import com.whisent.kubeloader.definition.meta.dependency.PackDependency;
 import com.whisent.kubeloader.utils.CodecUtil;
 import org.apache.maven.artifact.versioning.VersionRange;
 
@@ -9,14 +12,14 @@ import java.util.Optional;
 /**
  * @author ZZZank
  */
-record ImmutableDependency(
+public record ImmutableDependency(
     DependencyType type,
     String id,
     Optional<VersionRange> versionRange,
     Optional<String> reason,
     Optional<LoadOrdering> ordering
 ) implements PackDependency {
-    static final Codec<VersionRange> VERSION_RANGE_CODEC = Codec.STRING.comapFlatMap(
+    public static final Codec<VersionRange> VERSION_RANGE_CODEC = Codec.STRING.comapFlatMap(
         CodecUtil.wrapUnsafeFn(VersionRange::createFromVersionSpec),
         VersionRange::toString
     );

--- a/src/main/java/com/whisent/kubeloader/impl/depends/ImmutableMetaData.java
+++ b/src/main/java/com/whisent/kubeloader/impl/depends/ImmutableMetaData.java
@@ -1,6 +1,7 @@
-package com.whisent.kubeloader.definition.meta;
+package com.whisent.kubeloader.impl.depends;
 
 import com.mojang.serialization.Codec;
+import com.whisent.kubeloader.definition.meta.PackMetaData;
 import com.whisent.kubeloader.definition.meta.dependency.PackDependency;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
@@ -10,7 +11,7 @@ import java.util.*;
 /**
  * @author ZZZank
  */
-record ImmutableMetaData(
+public record ImmutableMetaData(
     String id,
     Optional<String> name,
     Optional<String> description,
@@ -18,5 +19,5 @@ record ImmutableMetaData(
     List<String> authors,
     List<PackDependency> dependencies
 ) implements PackMetaData {
-    static final Codec<ArtifactVersion> VERSION_CODEC = Codec.STRING.xmap(DefaultArtifactVersion::new, ArtifactVersion::toString);
+    public static final Codec<ArtifactVersion> VERSION_CODEC = Codec.STRING.xmap(DefaultArtifactVersion::new, ArtifactVersion::toString);
 }

--- a/src/main/java/com/whisent/kubeloader/impl/depends/PackDependencyValidator.java
+++ b/src/main/java/com/whisent/kubeloader/impl/depends/PackDependencyValidator.java
@@ -110,7 +110,7 @@ public class PackDependencyValidator {
     ) {
         var named = new HashMap<String, ContentPack>();
         for (var pack : packs) {
-            var namespace = pack.getNamespace();
+            var namespace = pack.id();
             var old = named.get(namespace);
             if (old == null) {
                 named.put(namespace, pack);

--- a/src/main/java/com/whisent/kubeloader/impl/dummy/DummyContentPack.java
+++ b/src/main/java/com/whisent/kubeloader/impl/dummy/DummyContentPack.java
@@ -2,37 +2,35 @@ package com.whisent.kubeloader.impl.dummy;
 
 import com.whisent.kubeloader.definition.ContentPack;
 import com.whisent.kubeloader.definition.PackLoadingContext;
+import com.whisent.kubeloader.definition.meta.PackMetaData;
 import dev.latvian.mods.kubejs.script.ScriptPack;
-import dev.latvian.mods.kubejs.script.ScriptType;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Map;
 import java.util.function.Function;
 
 /**
  * @author ZZZank
  */
 public class DummyContentPack implements ContentPack {
-    private final String namespace;
+    private final PackMetaData metaData;
     private final Function<PackLoadingContext, ScriptPack> toPack;
 
     public DummyContentPack(String namespace, Function<PackLoadingContext, ScriptPack> toPack) {
-        this.namespace = namespace;
+        this(PackMetaData.minimal(namespace), toPack);
+    }
+
+    public DummyContentPack(PackMetaData metaData, Function<PackLoadingContext, ScriptPack> toPack) {
+        this.metaData = metaData;
         this.toPack = toPack;
-    }
-
-    public DummyContentPack(String namespace, Map<ScriptType, ScriptPack> toPack) {
-        this(namespace, cx -> toPack.get(cx.type()));
-    }
-
-    @Override
-    public @NotNull String getNamespace() {
-        return namespace;
     }
 
     @Override
     public @Nullable ScriptPack getPack(PackLoadingContext context) {
         return toPack.apply(context);
+    }
+
+    @Override
+    public PackMetaData getMetaData() {
+        return metaData;
     }
 }

--- a/src/main/java/com/whisent/kubeloader/impl/mod/ModContentPack.java
+++ b/src/main/java/com/whisent/kubeloader/impl/mod/ModContentPack.java
@@ -4,6 +4,7 @@ import com.whisent.kubeloader.Kubeloader;
 import com.whisent.kubeloader.definition.ContentPack;
 import com.whisent.kubeloader.definition.PackLoadingContext;
 import com.whisent.kubeloader.definition.meta.PackMetaData;
+import com.whisent.kubeloader.impl.ContentPackBase;
 import dev.latvian.mods.kubejs.script.*;
 import net.minecraftforge.forgespi.language.IModInfo;
 import org.jetbrains.annotations.Nullable;
@@ -11,30 +12,22 @@ import org.jetbrains.annotations.Nullable;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.util.EnumMap;
-import java.util.Map;
 import java.util.jar.JarFile;
 
 /**
  * @author ZZZank
  */
-public class ModContentPack implements ContentPack {
+public class ModContentPack extends ContentPackBase {
     private final IModInfo mod;
-    private final Map<ScriptType, ScriptPack> packs = new EnumMap<>(ScriptType.class);
-    private final PackMetaData metaData;
 
     public ModContentPack(IModInfo mod, PackMetaData metaData) {
+        super(metaData);
         this.mod = mod;
-        this.metaData = metaData;
     }
 
     @Override
     @Nullable
-    public ScriptPack getPack(PackLoadingContext context) {
-        return packs.computeIfAbsent(context.type(), k -> createPack(context));
-    }
-
-    private ScriptPack createPack(PackLoadingContext context) {
+    protected ScriptPack createPack(PackLoadingContext context) {
         var pack = ContentPack.createEmptyPack(context, id());
 
         var prefix = Kubeloader.FOLDER_NAME + '/' + context.folderName() + '/';
@@ -55,15 +48,10 @@ public class ModContentPack implements ContentPack {
                     };
                     context.loadFile(pack, fileInfo, scriptSource);
                 });
+            return pack;
         } catch (IOException e) {
             return null;
         }
-        return pack;
-    }
-
-    @Override
-    public PackMetaData getMetaData() {
-        return metaData;
     }
 
     @Override

--- a/src/main/java/com/whisent/kubeloader/impl/mod/ModContentPack.java
+++ b/src/main/java/com/whisent/kubeloader/impl/mod/ModContentPack.java
@@ -33,11 +33,6 @@ public class ModContentPack implements ContentPack {
     }
 
     @Override
-    public @NotNull String getNamespace() {
-        return mod.getModId();
-    }
-
-    @Override
     @Nullable
     public ScriptPack getPack(PackLoadingContext context) {
         return packs.computeIfAbsent(context.type(), k -> createPack(context));

--- a/src/main/java/com/whisent/kubeloader/impl/mod/ModContentPack.java
+++ b/src/main/java/com/whisent/kubeloader/impl/mod/ModContentPack.java
@@ -39,7 +39,7 @@ public class ModContentPack implements ContentPack {
     }
 
     private ScriptPack createPack(PackLoadingContext context) {
-        var pack = createEmptyPack(context);
+        var pack = ContentPack.createEmptyPack(context, id());
 
         var prefix = Kubeloader.FOLDER_NAME + '/' + context.folderName() + '/';
         try (var file = new JarFile(mod.getOwningFile().getFile().getFilePath().toFile())) {

--- a/src/main/java/com/whisent/kubeloader/impl/mod/ModContentPack.java
+++ b/src/main/java/com/whisent/kubeloader/impl/mod/ModContentPack.java
@@ -1,7 +1,7 @@
 package com.whisent.kubeloader.impl.mod;
 
 import com.whisent.kubeloader.Kubeloader;
-import com.whisent.kubeloader.definition.ContentPack;
+import com.whisent.kubeloader.definition.ContentPackUtils;
 import com.whisent.kubeloader.definition.PackLoadingContext;
 import com.whisent.kubeloader.definition.meta.PackMetaData;
 import com.whisent.kubeloader.impl.ContentPackBase;
@@ -28,7 +28,7 @@ public class ModContentPack extends ContentPackBase {
     @Override
     @Nullable
     protected ScriptPack createPack(PackLoadingContext context) {
-        var pack = ContentPack.createEmptyPack(context, id());
+        var pack = ContentPackUtils.createEmptyPack(context, id());
 
         var prefix = Kubeloader.FOLDER_NAME + '/' + context.folderName() + '/';
         try (var file = new JarFile(mod.getOwningFile().getFile().getFilePath().toFile())) {

--- a/src/main/java/com/whisent/kubeloader/impl/mod/ModContentPackProvider.java
+++ b/src/main/java/com/whisent/kubeloader/impl/mod/ModContentPackProvider.java
@@ -38,13 +38,19 @@ public class ModContentPackProvider implements ContentPackProvider {
 
     private ContentPack scanSingle(Path path) {
         try (var file = new JarFile(path.toFile())) {
-            var entry = file.getEntry(Kubeloader.FOLDER_NAME);
-            if (entry == null || !entry.isDirectory()) {
+            var entry = file.getEntry(Kubeloader.FOLDER_NAME + '/' + Kubeloader.META_DATA_FILE_NAME);
+            if (entry == null) {
                 return null;
+            } else if (entry.isDirectory()) {
+                throw new RuntimeException(String.format(
+                    "%s should be a file, but got a directory",
+                    Kubeloader.META_DATA_FILE_NAME
+                ));
             }
-            return new ModContentPack(mod);
-        } catch (IOException e) {
+            return new ModContentPack(mod, ContentPack.loadMetaDataOrThrow(file.getInputStream(entry)));
+        } catch (Exception e) {
             // log
+            Kubeloader.LOGGER.error("Error when searching for ModContentPack in mod '{}'", mod.getModId(), e);
             return null;
         }
     }

--- a/src/main/java/com/whisent/kubeloader/impl/mod/ModContentPackProvider.java
+++ b/src/main/java/com/whisent/kubeloader/impl/mod/ModContentPackProvider.java
@@ -3,10 +3,10 @@ package com.whisent.kubeloader.impl.mod;
 import com.whisent.kubeloader.Kubeloader;
 import com.whisent.kubeloader.definition.ContentPack;
 import com.whisent.kubeloader.definition.ContentPackProvider;
+import com.whisent.kubeloader.definition.ContentPackUtils;
 import net.minecraftforge.forgespi.language.IModInfo;
 import org.jetbrains.annotations.NotNull;
 
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.jar.JarFile;
@@ -47,7 +47,7 @@ public class ModContentPackProvider implements ContentPackProvider {
                     Kubeloader.META_DATA_FILE_NAME
                 ));
             }
-            return new ModContentPack(mod, ContentPack.loadMetaDataOrThrow(file.getInputStream(entry)));
+            return new ModContentPack(mod, ContentPackUtils.loadMetaDataOrThrow(file.getInputStream(entry)));
         } catch (Exception e) {
             // log
             Kubeloader.LOGGER.error("Error when searching for ModContentPack in mod '{}'", mod.getModId(), e);

--- a/src/main/java/com/whisent/kubeloader/impl/path/PathContentPack.java
+++ b/src/main/java/com/whisent/kubeloader/impl/path/PathContentPack.java
@@ -74,11 +74,6 @@ public class PathContentPack implements ContentPack {
     }
 
     @Override
-    public @NotNull String getNamespace() {
-        return namespace;
-    }
-
-    @Override
     public @Nullable ScriptPack getPack(PackLoadingContext context) {
         var scriptPath = base.resolve(context.folderName());
         if (!Files.isDirectory(scriptPath)) {

--- a/src/main/java/com/whisent/kubeloader/impl/path/PathContentPack.java
+++ b/src/main/java/com/whisent/kubeloader/impl/path/PathContentPack.java
@@ -4,6 +4,7 @@ import com.google.gson.JsonObject;
 import com.mojang.serialization.JsonOps;
 import com.whisent.kubeloader.Kubeloader;
 import com.whisent.kubeloader.definition.ContentPack;
+import com.whisent.kubeloader.definition.ContentPackUtils;
 import com.whisent.kubeloader.definition.PackLoadingContext;
 import com.whisent.kubeloader.definition.meta.PackMetaData;
 import dev.latvian.mods.kubejs.KubeJS;
@@ -54,7 +55,7 @@ public class PathContentPack implements ContentPack {
         if (!Files.isDirectory(scriptPath)) {
             return null;
         }
-        var pack = ContentPack.createEmptyPack(context, id());
+        var pack = ContentPackUtils.createEmptyPack(context, id());
         KubeJS.loadScripts(pack, scriptPath, "");
         for (var fileInfo : pack.info.scripts) {
             var scriptSource = (ScriptSource.FromPath) (info) -> scriptPath.resolve(info.file);

--- a/src/main/java/com/whisent/kubeloader/impl/path/PathContentPack.java
+++ b/src/main/java/com/whisent/kubeloader/impl/path/PathContentPack.java
@@ -54,7 +54,7 @@ public class PathContentPack implements ContentPack {
         if (!Files.isDirectory(scriptPath)) {
             return null;
         }
-        var pack = createEmptyPack(context);
+        var pack = ContentPack.createEmptyPack(context, id());
         KubeJS.loadScripts(pack, scriptPath, "");
         for (var fileInfo : pack.info.scripts) {
             var scriptSource = (ScriptSource.FromPath) (info) -> scriptPath.resolve(info.file);

--- a/src/main/java/com/whisent/kubeloader/impl/path/PathContentPack.java
+++ b/src/main/java/com/whisent/kubeloader/impl/path/PathContentPack.java
@@ -3,36 +3,27 @@ package com.whisent.kubeloader.impl.path;
 import com.google.gson.JsonObject;
 import com.mojang.serialization.JsonOps;
 import com.whisent.kubeloader.Kubeloader;
-import com.whisent.kubeloader.cpconfig.JsonReader;
 import com.whisent.kubeloader.definition.ContentPack;
 import com.whisent.kubeloader.definition.PackLoadingContext;
 import com.whisent.kubeloader.definition.meta.PackMetaData;
 import dev.latvian.mods.kubejs.KubeJS;
 import dev.latvian.mods.kubejs.script.ScriptPack;
 import dev.latvian.mods.kubejs.script.ScriptSource;
-import dev.latvian.mods.kubejs.util.JsonIO;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Map;
 
 /**
  * @author ZZZank
  */
 public class PathContentPack implements ContentPack {
     private final Path base;
-    private final String namespace;
     private final PackMetaData metaData;
-
-    private final Map config;
 
     public PathContentPack(Path base) {
         this.base = base;
-        this.namespace = base.getFileName().toString();
-        this.config = getCustomOrDefaultConfig();
         this.metaData = loadMetaData(base);
     }
 
@@ -44,33 +35,17 @@ public class PathContentPack implements ContentPack {
             );
             if (result.result().isPresent()) {
                 return result.result().get();
-            } else {
-                return ContentPack.super.getMetaData();
             }
+            var errorMessage = result.error().orElseThrow().message();
+            throw new RuntimeException("Error when parsing metadata: " + errorMessage);
         } catch (IOException e) {
-            return ContentPack.super.getMetaData();
+            throw new RuntimeException(e);
         }
     }
 
     @Override
     public PackMetaData getMetaData() {
         return metaData;
-    }
-
-    //若不存在自定义config则返回内部config
-    private Map getCustomOrDefaultConfig() {
-        Path customConfigPath = Kubeloader.ConfigPath.resolve(namespace + ".json");
-        if (Files.notExists(customConfigPath)) {
-            try {
-                JsonObject obj = JsonReader.getJsonObject(base.resolve("config.json"));
-                JsonIO.write(customConfigPath, obj);
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-            return JsonReader.loadConfig(base.resolve("config.json"));
-        } else {
-            return JsonReader.loadConfig(customConfigPath);
-        }
     }
 
     @Override
@@ -90,6 +65,6 @@ public class PathContentPack implements ContentPack {
 
     @Override
     public String toString() {
-        return "PathContentPack[namespace='%s']".formatted(namespace);
+        return "PathContentPack[namespace='%s']".formatted(id());
     }
 }

--- a/src/main/java/com/whisent/kubeloader/impl/zip/ZipContentPack.java
+++ b/src/main/java/com/whisent/kubeloader/impl/zip/ZipContentPack.java
@@ -1,7 +1,6 @@
 package com.whisent.kubeloader.impl.zip;
 
-import com.whisent.kubeloader.Kubeloader;
-import com.whisent.kubeloader.definition.ContentPack;
+import com.whisent.kubeloader.definition.ContentPackUtils;
 import com.whisent.kubeloader.definition.PackLoadingContext;
 import com.whisent.kubeloader.definition.meta.PackMetaData;
 import com.whisent.kubeloader.impl.ContentPackBase;
@@ -27,7 +26,7 @@ public class ZipContentPack extends ContentPackBase {
     @Override
     @Nullable
     protected ScriptPack createPack(PackLoadingContext context) {
-        var pack = ContentPack.createEmptyPack(context, id());
+        var pack = ContentPackUtils.createEmptyPack(context, id());
         var prefix = context.folderName() + '/';
         try (var zipFile = new ZipFile(path.toFile())) {
             zipFile.stream()

--- a/src/main/java/com/whisent/kubeloader/impl/zip/ZipContentPack.java
+++ b/src/main/java/com/whisent/kubeloader/impl/zip/ZipContentPack.java
@@ -75,7 +75,7 @@ public class ZipContentPack implements ContentPack {
     }
 
     private ScriptPack createPack(PackLoadingContext context) throws IOException {
-        var pack = createEmptyPack(context);
+        var pack = ContentPack.createEmptyPack(context, id());
         var prefix = context.folderName() + '/';
         zipFile.stream()
             .filter(e -> !e.isDirectory())

--- a/src/main/java/com/whisent/kubeloader/impl/zip/ZipContentPack.java
+++ b/src/main/java/com/whisent/kubeloader/impl/zip/ZipContentPack.java
@@ -12,6 +12,7 @@ import org.jetbrains.annotations.Nullable;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.zip.ZipFile;
 

--- a/src/main/java/com/whisent/kubeloader/impl/zip/ZipContentPack.java
+++ b/src/main/java/com/whisent/kubeloader/impl/zip/ZipContentPack.java
@@ -79,14 +79,6 @@ public class ZipContentPack implements ContentPack {
         }
     }
 
-    @Override
-    public @NotNull String getNamespace() {
-        if (namespace == null) {
-            namespace = computeNamespace();
-        }
-        return namespace;
-    }
-
     private String computeNamespace() {
         Set<String> firstLevelFolders = zipFile.stream()
                 .map(ZipEntry::getName)
@@ -198,7 +190,6 @@ public class ZipContentPack implements ContentPack {
     }
     @Override
     public String toString() {
-        return "ZipContentPack[namespace=%s]".formatted(getNamespace());
+        return "ZipContentPack[namespace=%s]".formatted(metaData.id());
     }
-
 }

--- a/src/main/java/com/whisent/kubeloader/impl/zip/ZipContentPackProvider.java
+++ b/src/main/java/com/whisent/kubeloader/impl/zip/ZipContentPackProvider.java
@@ -49,7 +49,7 @@ public class ZipContentPackProvider implements ContentPackProvider {
                 ));
             }
             var metadata = ContentPack.loadMetaDataOrThrow(zipFile.getInputStream(entry));
-            return new ZipContentPack(file, metadata);
+            return new ZipContentPack(file.toPath(), metadata);
         } catch (Exception e) {
             Kubeloader.LOGGER.error("Error when scanning zip file: {}", file.getName(), e);
             return null;

--- a/src/main/java/com/whisent/kubeloader/impl/zip/ZipContentPackProvider.java
+++ b/src/main/java/com/whisent/kubeloader/impl/zip/ZipContentPackProvider.java
@@ -3,6 +3,7 @@ package com.whisent.kubeloader.impl.zip;
 import com.whisent.kubeloader.Kubeloader;
 import com.whisent.kubeloader.definition.ContentPack;
 import com.whisent.kubeloader.definition.ContentPackProvider;
+import com.whisent.kubeloader.definition.ContentPackUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
@@ -48,7 +49,7 @@ public class ZipContentPackProvider implements ContentPackProvider {
                     Kubeloader.META_DATA_FILE_NAME
                 ));
             }
-            var metadata = ContentPack.loadMetaDataOrThrow(zipFile.getInputStream(entry));
+            var metadata = ContentPackUtils.loadMetaDataOrThrow(zipFile.getInputStream(entry));
             return new ZipContentPack(file.toPath(), metadata);
         } catch (Exception e) {
             Kubeloader.LOGGER.error("Error when scanning zip file: {}", file.getName(), e);

--- a/src/main/java/com/whisent/kubeloader/mixin/ScriptManagerMixin.java
+++ b/src/main/java/com/whisent/kubeloader/mixin/ScriptManagerMixin.java
@@ -43,7 +43,7 @@ public abstract class ScriptManagerMixin implements SortablePacksHolder {
         }
 
         var indexed = packs.stream().collect(Collectors.toMap(
-            ContentPack::getNamespace,
+            ContentPack::id,
             Function.identity()
         ));
 
@@ -52,7 +52,7 @@ public abstract class ScriptManagerMixin implements SortablePacksHolder {
         for (var contentPack : packs) {
             Kubeloader.LOGGER.debug("寻找到contentPack: {}", contentPack);
             var scriptPack = contentPack.getPack(context);
-            var namespace = contentPack.getNamespace(context);
+            var namespace = contentPack.id();
 
             List<ScriptPack> scriptPacks;
             if (KubeJS.MOD_ID.equals(namespace)) {


### PR DESCRIPTION
- 去掉了 ContentPack 的 namespace，全部用 metadata 中的 id 提供
- `"type": "MOD"` 被分离到了 DependencySource ，依赖模组与依赖内容包因此都可以使用 5 种依赖类型
  - `"source": "PACK"`：不填写时的默认值，表明这项依赖关系是对另一个ContentPack的关系
  - `"source": "MOD"`：表明这项依赖关系是对模组的依赖关系
- `contentpack.json` 的读取提前，metadata有效成为ContentPack有效的先决条件，比加载ContentPack的内容更早
    - 对于每种 ContentPack ，其 contentpack.json 的路径都假定只有一处，预防扫描全部文件的性能问题
- ZipContentPack 每次重载都会重新在路径里扫描，因此可以在游戏运行时加减 ContentPack
- zip形式内容包现在需要把文件放在根目录。一个zip内含一个内容包是之前已经定下来的，所以除了少一层文件夹之外没有什么功能变化
    - `namespace` 先前是由文件夹名提供，现在标准化为 metadata 中的 id。

---

PR的代码改动已经比较完备，但是这些改动肯定需要在README里写出来，~~在完善PR描述之前暂且标注为draft~~ PR里的描述可以作为摘要参考 ¯\\\_(ツ)_/¯

版本号再往后，比如0.1.0甚至1.0.0的时候，做这些有破坏性的改动就肯定比较纠结了，现在快刀斩乱麻